### PR TITLE
Improve error messages

### DIFF
--- a/Sources/Cloud/Builder.swift
+++ b/Sources/Cloud/Builder.swift
@@ -65,7 +65,7 @@ extension Builder {
 
 extension Builder {
     private func buildNative(targetName: String, flags: String) async throws {
-        let spinner = ui.spinner(label: #"Building target "\#(targetName)""#)
+        let spinner = UI.spinner(label: #"Building target "\#(targetName)""#)
         defer { spinner.stop() }
 
         try await shellOut(
@@ -83,7 +83,7 @@ extension Builder {
         imageName: String,
         flags: String
     ) async throws {
-        let spinner = ui.spinner(label: #"Building target "\#(targetName)""#)
+        let spinner = UI.spinner(label: #"Building target "\#(targetName)""#)
         defer { spinner.stop() }
 
         try await shellOut(

--- a/Sources/Cloud/Command/CancelCommand.swift
+++ b/Sources/Cloud/Command/CancelCommand.swift
@@ -8,12 +8,12 @@ extension Command {
         @OptionGroup var options: Options
 
         func invoke(with context: Context) async throws {
-            let spinner = ui.spinner(label: "Cancelling changes")
+            let spinner = UI.spinner(label: "Cancelling changes")
             do {
                 let prepared = try await prepare(with: context)
                 let output = try await prepared.client.invoke(command: "cancel")
                 spinner.stop()
-                ui.writeBlock(output)
+                UI.writeBlock(output)
             } catch {
                 spinner.stop()
                 throw error

--- a/Sources/Cloud/Command/DeployCommand.swift
+++ b/Sources/Cloud/Command/DeployCommand.swift
@@ -8,12 +8,12 @@ extension Command {
         @OptionGroup var options: Options
 
         func invoke(with context: Context) async throws {
-            let spinner = ui.spinner(label: "Deploying changes")
+            let spinner = UI.spinner(label: "Deploying changes")
             do {
                 let prepared = try await prepare(with: context, buildTargets: true)
                 let output = try await prepared.client.invoke(command: "up", arguments: ["--skip-preview", "--yes"])
                 spinner.stop()
-                ui.writeBlock(output)
+                UI.writeBlock(output)
             } catch {
                 spinner.stop()
                 throw error

--- a/Sources/Cloud/Command/PreviewCommand.swift
+++ b/Sources/Cloud/Command/PreviewCommand.swift
@@ -8,12 +8,12 @@ extension Command {
         @OptionGroup var options: Options
 
         func invoke(with context: Context) async throws {
-            let spinner = ui.spinner(label: "Generating preview")
+            let spinner = UI.spinner(label: "Generating preview")
             do {
                 let prepared = try await prepare(with: context)
                 let output = try await prepared.client.invoke(command: "preview")
                 spinner.stop()
-                ui.writeBlock(output)
+                UI.writeBlock(output)
             } catch {
                 spinner.stop()
                 throw error

--- a/Sources/Cloud/Command/RemoveCommand.swift
+++ b/Sources/Cloud/Command/RemoveCommand.swift
@@ -8,13 +8,13 @@ extension Command {
         @OptionGroup var options: Options
 
         func invoke(with context: Context) async throws {
-            let spinner = ui.spinner(label: "Removing application")
+            let spinner = UI.spinner(label: "Removing application")
             do {
                 let prepared = try await prepare(with: context)
                 let output = try await prepared.client.invoke(
                     command: "destroy", arguments: ["--continue-on-error", "--skip-preview", "--yes"])
                 spinner.stop()
-                ui.writeBlock(output)
+                UI.writeBlock(output)
             } catch {
                 spinner.stop()
                 throw error

--- a/Sources/Cloud/Command/RootCommand.swift
+++ b/Sources/Cloud/Command/RootCommand.swift
@@ -103,7 +103,7 @@ extension Command.RunCommand {
         do {
             try await context.home.pushState(context: context)
         } catch {
-            ui.error(error)
+            UI.error(error)
         }
     }
 }

--- a/Sources/Cloud/Project.swift
+++ b/Sources/Cloud/Project.swift
@@ -41,19 +41,20 @@ extension Project {
                 builder: builder
             )
             await Context.$current.withValue(context) {
-                ui.writeHeader()
+                UI.writeHeader()
                 do {
                     try await command.invoke(with: context)
                     try await command.complete(with: context)
                 } catch {
-                    ui.error(error)
+                    UI.error(error)
                 }
-                ui.writeFooter()
+
+                UI.writeFooter()
             }
         default:
-            ui.newLine()
-            ui.error("➜  Invalid command:   ensure you pass a stage, ie: --stage prod")
-            ui.newLine()
+            UI.newLine()
+            UI.error("➜  Invalid command:   ensure you pass a stage, ie: --stage prod")
+            UI.newLine()
         }
     }
 }

--- a/Sources/Cloud/Project.swift
+++ b/Sources/Cloud/Project.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Command
 import ConsoleKitTerminal
 
 public protocol Project: Sendable {
@@ -45,6 +46,9 @@ extension Project {
                 do {
                     try await command.invoke(with: context)
                     try await command.complete(with: context)
+                } catch let CommandError.terminated(errorCode, message) {
+                    UI.error("Command terminated with error \(errorCode):")
+                    UI.error(message)
                 } catch {
                     UI.error(error)
                 }

--- a/Sources/Cloud/Pulumi/PulumiClient.swift
+++ b/Sources/Cloud/Pulumi/PulumiClient.swift
@@ -46,7 +46,7 @@ extension Pulumi.Client {
 
 extension Pulumi.Client {
     public func setup() async throws {
-        let spinner = ui.spinner(label: "Installing Swift Cloud")
+        let spinner = UI.spinner(label: "Installing Swift Cloud")
         defer { spinner.stop() }
 
         let arch = Architecture.current.pulumiArchitecture

--- a/Sources/Cloud/UI/UI.swift
+++ b/Sources/Cloud/UI/UI.swift
@@ -1,7 +1,7 @@
 import ConsoleKitTerminal
 
-public enum ui {}
+public enum UI {}
 
-extension ui {
+extension UI {
     public static let cli = Terminal()
 }

--- a/Sources/Cloud/UI/UIFooter.swift
+++ b/Sources/Cloud/UI/UIFooter.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-extension ui {
+extension UI {
     public static func writeFooter() {
         let diff = Date().timeIntervalSince(Context.current.startDate)
 
-        ui.newLine()
-        ui.write("➜", width: .small, color: .cyan, bold: true)
-        ui.write("Done:", width: .medium, color: .cyan, bold: true)
-        ui.write(String(format: "%.2fs", diff))
-        ui.newLine()
-        ui.newLine()
+        UI.newLine()
+        UI.write("➜", width: .small, color: .cyan, bold: true)
+        UI.write("Done:", width: .medium, color: .cyan, bold: true)
+        UI.write(String(format: "%.2fs", diff))
+        UI.newLine()
+        UI.newLine()
     }
 }

--- a/Sources/Cloud/UI/UIHeader.swift
+++ b/Sources/Cloud/UI/UIHeader.swift
@@ -1,19 +1,19 @@
-extension ui {
+extension UI {
     public static func writeHeader() {
         cli.clear(lines: 3)
-        ui.newLine()
+        UI.newLine()
 
-        ui.write("Swift Cloud", color: .cyan, bold: true, newLine: true)
-        ui.newLine()
+        UI.write("Swift Cloud", color: .cyan, bold: true, newLine: true)
+        UI.newLine()
 
-        ui.write("➜", width: .small, color: .cyan, bold: true)
-        ui.write("Package", width: .medium, bold: true)
-        ui.write(Context.current.packageName, newLine: true)
+        UI.write("➜", width: .small, color: .cyan, bold: true)
+        UI.write("Package", width: .medium, bold: true)
+        UI.write(Context.current.packageName, newLine: true)
 
-        ui.write("", width: .small)
-        ui.write("Stage", width: .medium, bold: true)
-        ui.write(Context.current.stage, newLine: true)
+        UI.write("", width: .small)
+        UI.write("Stage", width: .medium, bold: true)
+        UI.write(Context.current.stage, newLine: true)
 
-        ui.newLine()
+        UI.newLine()
     }
 }

--- a/Sources/Cloud/UI/UIHelpers.swift
+++ b/Sources/Cloud/UI/UIHelpers.swift
@@ -1,13 +1,13 @@
 import ConsoleKitTerminal
 import Foundation
 
-extension ui {
+extension UI {
     public static func newLine() {
         cli.output("", newLine: true)
     }
 }
 
-extension ui {
+extension UI {
     public static func clear(_ type: ConsoleClear) {
         cli.clear(type)
     }
@@ -21,7 +21,7 @@ extension ui {
     }
 }
 
-extension ui {
+extension UI {
     public enum ColumnSize: Int {
         case small = 3
         case medium = 12
@@ -47,18 +47,18 @@ extension ui {
     }
 }
 
-extension ui {
+extension UI {
     public static func writeBlock(_ text: String) {
         let lines = text.split(separator: .newlineSequence)
         for line in lines {
-            ui.write("|", width: .small, color: .yellow, bold: true)
-            ui.write("\(line)")
-            ui.newLine()
+            UI.write("|", width: .small, color: .yellow, bold: true)
+            UI.write("\(line)")
+            UI.newLine()
         }
     }
 }
 
-extension ui {
+extension UI {
     public static func error(_ error: Error) {
         cli.error("\(error)")
     }
@@ -68,7 +68,7 @@ extension ui {
     }
 }
 
-extension ui {
+extension UI {
     public final class Spinner: @unchecked Sendable {
         fileprivate static let shared = Spinner()
 


### PR DESCRIPTION
When trying SwiftCloud, I noticed that the errors weren't verbose enough.
I debugged it, and found that the error printed via `UI.error(error)` only included the exit code of the command, without `stderr`.

This PR uses that information, and now that Command is in use, takes the error message in case the error is `CommandError.terminated`. See before and after images, and the change in `Sources/Cloud/Project.swift` in the 2nd commit.

Additionally, in the 1st commit, I've renamed the `ui` namespace to be uppercased and more in line with namespaces in Swift (such as the AWS change done recently).

**Before**:
![iTerm2-2024-08-11-11 59 55@2x](https://github.com/user-attachments/assets/35a28f7d-942f-47be-a918-387369a76c4a)

**After**:

![iTerm2-2024-08-11-12 02 57@2x](https://github.com/user-attachments/assets/8c8cef1f-dd34-4402-a2d1-740c35805f14)
