### PR TITLE
Fix AnyEncodable issue in DynamoDB initializer

### DIFF
--- a/Sources/AWSCloud/Components/DynamoDB.swift
+++ b/Sources/AWSCloud/Components/DynamoDB.swift
@@ -26,7 +26,7 @@ extension AWS {
                     "attributes": [
                         ["name": primaryIndex.partitionKey.name, "type": primaryIndex.partitionKey.type.rawValue],
                         primaryIndex.sortKey.map { ["name": $0.name, "type": $0.type.rawValue] },
-                    ].compacted(),
+                    ].compactMap { $0 },
                     "globalSecondaryIndexes": secondaryIndexes.map { index in
                         [
                             "name": index.partitionKey.name,


### PR DESCRIPTION
When creating a DynamoDB resource, only with a partition key and no sort key as the primary index, deploying throws the following error:

> invalidValue(Algorithms.CompactedCollection<Swift.Array<Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>>, Swift.Dictionary<Swift.String, Swift.String>>(base: [Optional(["name": "id", "type": "S"]), nil], startIndex: Algorithms.CompactedCollection<Swift.Array<Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>>, Swift.Dictionary<Swift.String, Swift.String>>.Index(base: 0)), Swift.EncodingError.Context(codingPath: [CodingKeys(stringValue: "resources", intValue: nil), _DictionaryCodingKey(stringValue: "dev-newsletter-subscriptions", intValue: nil), CodingKeys(stringValue: "properties", intValue: nil), _DictionaryCodingKey(stringValue: "attributes", intValue: nil)], debugDescription: "**AnyEncodable value cannot be encoded**", underlyingError: nil))

When looking into the code, it turns out that AnyEncodable has a hard time with a `CompactedCollection`. This PR changes the call in the DynamoDB initializer from `.compacted()` to `.compactMap { $0 }`.

Another approach could be to implement the encoding for `CompactedCollection`s in the `_AnyEncodable.encode(to:)` method.