### PR TITLE
feat: DigitalOcean

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -6,4 +6,5 @@ builder:
         - CloudAWS
         - CloudCore
         - CloudCloudflare
+        - CloudDigitalOcean
         - CloudFastly

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "CloudAWS", targets: ["CloudAWS"]),
         .library(name: "CloudCloudflare", targets: ["CloudCloudflare"]),
         .library(name: "CloudCore", targets: ["CloudCore"]),
+        .library(name: "CloudDigitalOcean", targets: ["CloudDigitalOcean"]),
         .library(name: "CloudFastly", targets: ["CloudFastly"]),
         .library(name: "CloudSDK", targets: ["CloudSDK"]),
     ],
@@ -30,6 +31,7 @@ let package = Package(
                 "CloudAWS",
                 "CloudCloudflare",
                 "CloudCore",
+                "CloudDigitalOcean",
                 "CloudFastly",
             ]
         ),
@@ -51,6 +53,10 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "SotoCore", package: "soto-core"),
             ]
+        ),
+        .target(
+            name: "CloudDigitalOcean",
+            dependencies: ["CloudCore"]
         ),
         .target(
             name: "CloudFastly",

--- a/Sources/Cloud/Cloud.swift
+++ b/Sources/Cloud/Cloud.swift
@@ -1,4 +1,5 @@
 @_exported import CloudAWS
 @_exported import CloudCloudflare
 @_exported import CloudCore
+@_exported import CloudDigitalOcean
 @_exported import CloudFastly

--- a/Sources/CloudAWS/AWSProject.swift
+++ b/Sources/CloudAWS/AWSProject.swift
@@ -9,8 +9,8 @@ extension AWSProject {
         "us-east-1"
     }
 
-    public var home: Home.AWS {
-        .init(region: region)
+    public var home: any HomeProvider {
+        Home.AWS(region: region)
     }
 
     public var providers: [Provider] {

--- a/Sources/CloudAWS/AWSProject.swift
+++ b/Sources/CloudAWS/AWSProject.swift
@@ -10,7 +10,7 @@ extension AWSProject {
     }
 
     public var home: Home.AWS {
-        Home.AWS(region: region)
+        .init(region: region)
     }
 
     public var providers: [Provider] {

--- a/Sources/CloudAWS/Components/WebServer.swift
+++ b/Sources/CloudAWS/Components/WebServer.swift
@@ -64,7 +64,7 @@ extension AWS {
 
             let dockerFilePath = Docker.Dockerfile.filePath(name)
 
-            self.environment = Environment(environment, shape: .keyValuePairs)
+            self.environment = Environment(environment, shape: .nameValueList)
             self.environment["PORT"] = "\(instancePort)"
 
             cluster = AWS.Cluster(

--- a/Sources/CloudAWS/Resources/DockerImage.swift
+++ b/Sources/CloudAWS/Resources/DockerImage.swift
@@ -12,8 +12,8 @@ extension AWS {
             _ name: String,
             imageRepository: ImageRepository,
             dockerFilePath: String,
-            context: String? = nil,
-            platform: String? = nil,
+            context: String = Context.projectDirectory,
+            platform: String = Architecture.current.dockerPlatform,
             options: Resource.Options? = nil
         ) {
             resource = Resource(
@@ -21,9 +21,9 @@ extension AWS {
                 type: "awsx:ecr:Image",
                 properties: [
                     "repositoryUrl": "\(imageRepository.url)",
-                    "context": "\(context ?? Context.projectDirectory)",
+                    "context": "\(context)",
                     "dockerfile": "\(dockerFilePath)",
-                    "platform": "\(platform ?? Architecture.current.dockerPlatform)",
+                    "platform": "\(platform)",
                     "args": ["DOCKER_BUILDKIT": "1"],
                 ],
                 options: options

--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -75,7 +75,7 @@ extension Builder {
             targetName: targetName,
             architecture: architecture,
             imageName: imageName,
-            flags: ["--static-swift-stdlib", "-Xlinker", "-ljemalloc"]
+            flags: ["--static-swift-stdlib"]
         )
     }
 }

--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -60,6 +60,27 @@ extension Builder {
 }
 
 extension Builder {
+    public func buildUbuntu(targetName: String, architecture: Architecture = .current) async throws {
+        let swiftVersion = try await currentSwiftVersion()
+        let imageName: String
+        switch swiftVersion {
+        case "5.10":
+            imageName = "swift:5.10-noble"
+        case "6.0":
+            imageName = "swift:6.0-noble"
+        default:
+            fatalError("Unsupported Swift version: \(swiftVersion)")
+        }
+        try await buildDocker(
+            targetName: targetName,
+            architecture: architecture,
+            imageName: imageName,
+            flags: ["--static-swift-stdlib", "-Xlinker", "-ljemalloc"]
+        )
+    }
+}
+
+extension Builder {
     public func buildWasm(targetName: String, architecture: Architecture = .current) async throws {
         let swiftVersion = try await currentSwiftVersion()
         let imageName: String

--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -136,6 +136,9 @@ extension Builder {
         let spinner = UI.spinner(label: #"Building target "\#(targetName)""#)
         defer { spinner.stop() }
 
+        let buildCommand = "swift build -c release --product \(targetName) \(flags.joined(separator: " "))"
+        spinner.push(buildCommand)
+
         try await shellOut(
             to: "docker",
             arguments: [
@@ -146,7 +149,7 @@ extension Builder {
                 "-w", "/workspace",
                 imageName,
                 "bash", "-cl",
-                "\(pre) && swift build -c release --product \(targetName) \(flags.joined(separator: " "))",
+                "\(pre) && \(buildCommand)",
             ],
             onEvent: { spinner.push($0.string()) }
         )

--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -32,7 +32,7 @@ extension Builder {
 }
 
 extension Builder {
-    public func buildAmazonLinux(targetName: String) async throws {
+    public func buildAmazonLinux(targetName: String, architecture: Architecture = .current) async throws {
         if isAmazonLinux() {
             try await buildNative(
                 targetName: targetName,
@@ -51,6 +51,7 @@ extension Builder {
             }
             try await buildDocker(
                 targetName: targetName,
+                architecture: architecture,
                 imageName: imageName,
                 flags: ["--static-swift-stdlib"]
             )
@@ -106,6 +107,7 @@ extension Builder {
 
     private func buildDocker(
         targetName: String,
+        architecture: Architecture = .current,
         imageName: String,
         flags: [String],
         pre: String = ":"
@@ -117,7 +119,7 @@ extension Builder {
             to: "docker",
             arguments: [
                 "run",
-                "--platform", "linux/\(Architecture.current.dockerPlatform)",
+                "--platform", "linux/\(architecture.dockerPlatform)",
                 "--rm",
                 "-v", "\(Files.currentDirectoryPath()):/workspace",
                 "-w", "/workspace",

--- a/Sources/CloudCore/Context.swift
+++ b/Sources/CloudCore/Context.swift
@@ -15,7 +15,7 @@ public final class Context: Sendable {
     }
 
     public var isProduction: Bool {
-        stage == "production" || stage == "prod"
+        stage == "production" || stage == "prod" || stage == "main" || stage == "master"
     }
 
     init(stage: String, project: any Project, package: Package, store: Store, builder: Builder) {

--- a/Sources/CloudCore/Docker/Docker.swift
+++ b/Sources/CloudCore/Docker/Docker.swift
@@ -42,4 +42,21 @@ extension Docker.Dockerfile {
         CMD ["--hostname", "0.0.0.0", "--port", "\(port)"]
         """
     }
+
+    public static func ubuntu(targetName: String, architecture: Architecture = .current, port: Int) -> String {
+        """
+        FROM ubuntu:noble
+
+        WORKDIR /app/
+
+        COPY ./.build/\(architecture.swiftBuildLinuxDirectory)/release/\(targetName) .
+
+        ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static
+
+        EXPOSE \(port)
+
+        ENTRYPOINT [ "./\(targetName)" ]
+        CMD ["--hostname", "0.0.0.0", "--port", "\(port)"]
+        """
+    }
 }

--- a/Sources/CloudCore/Environment.swift
+++ b/Sources/CloudCore/Environment.swift
@@ -7,11 +7,17 @@ public protocol EnvironmentProvider {
 public final class Environment: Encodable, @unchecked Sendable {
     public enum EncodingShape: String, Codable {
         case keyValue
-        case keyValuePairs
+        case nameValueList
+        case keyValueList
+    }
+
+    private struct NameValuePair: Codable {
+        let name: String
+        let value: String
     }
 
     private struct KeyValuePair: Codable {
-        let name: String
+        let key: String
         let value: String
     }
 
@@ -39,8 +45,11 @@ public final class Environment: Encodable, @unchecked Sendable {
         switch shape {
         case .keyValue:
             try container.encode(store.reduce(into: [:]) { $0[$1.key] = "\($1.value)" })
-        case .keyValuePairs:
-            let pairs = store.map { KeyValuePair(name: $0.key, value: "\($0)") }
+        case .keyValueList:
+            let pairs = store.map { KeyValuePair(key: $0.key, value: "\($0)") }
+            try container.encode(pairs)
+        case .nameValueList:
+            let pairs = store.map { NameValuePair(name: $0.key, value: "\($0)") }
             try container.encode(pairs)
         }
     }

--- a/Sources/CloudCore/Project.swift
+++ b/Sources/CloudCore/Project.swift
@@ -3,15 +3,23 @@ import Command
 import ConsoleKitTerminal
 
 public protocol Project: Sendable {
-    associatedtype ProjectHomeProvider: HomeProvider
-
     init()
 
-    var home: ProjectHomeProvider { get }
+    var home: any HomeProvider { get }
 
     var providers: [Provider] { get }
 
     func build() async throws -> Outputs
+}
+
+extension Project {
+    var providers: [Provider] {
+        []
+    }
+
+    var home: Home.Local {
+        .init()
+    }
 }
 
 extension Project {

--- a/Sources/CloudCore/Project.swift
+++ b/Sources/CloudCore/Project.swift
@@ -13,12 +13,12 @@ public protocol Project: Sendable {
 }
 
 extension Project {
-    var providers: [Provider] {
+    public var providers: [Provider] {
         []
     }
 
-    var home: Home.Local {
-        .init()
+    public var home: any HomeProvider {
+        Home.Local()
     }
 }
 

--- a/Sources/CloudCore/Pulumi/PulumiPlugins.swift
+++ b/Sources/CloudCore/Pulumi/PulumiPlugins.swift
@@ -38,6 +38,13 @@ extension Pulumi.Plugin {
         repo: "pulumi/pulumi-cloudflare"
     )
 
+    // https://github.com/pulumi/pulumi-digitalocean
+    public static let digitalocean = Pulumi.Plugin(
+        name: "digitalocean",
+        version: "4.38.0",
+        repo: "pulumi/pulumi-digitalocean"
+    )
+
     // https://github.com/pulumi/pulumi-fastly
     public static let fastly = Pulumi.Plugin(
         name: "fastly",

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -24,6 +24,7 @@ extension DigitalOcean {
             targetName: String,
             registryName: String,
             region: Region = .nyc3,
+            instanceSize: InstanceSize = .shared_1vCPU_512mb,
             instancePort: Int = 8080,
             autoScaling: AutoScalingConfiguration? = nil,
             environment: [String: CustomStringConvertible]? = nil,
@@ -78,6 +79,7 @@ extension DigitalOcean {
                                     "digest": image.output.keyPath("digest"),
                                 ],
                                 "httpPort": instancePort,
+                                "instanceSizeSlug": instanceSize.slug,
                                 "autoscaling": autoScaling.map {
                                     [
                                         "minInstanceCount": $0.minimumConcurrency,
@@ -103,6 +105,29 @@ extension DigitalOcean {
             }
         }
     }
+}
+
+extension DigitalOcean.App {
+    public enum InstanceSize: Sendable {
+        case shared(vCPU: Int, memory: Double)
+        case dedicated(vCPU: Int, memory: Double)
+
+        public var slug: String {
+            switch self {
+            case let .shared(vCPU, memory):
+                return "apps-s-\(vCPU)vcpu-\(memory)gb"
+            case let .dedicated(vCPU, memory):
+                return "apps-d-\(vCPU)vcpu-\(memory)gb"
+            }
+        }
+    }
+}
+
+extension DigitalOcean.App.InstanceSize {
+    public static let shared_1vCPU_512mb = Self.shared(vCPU: 1, memory: 0.5)
+    public static let shared_1vCPU_1gb = Self.shared(vCPU: 1, memory: 1)
+    public static let shared_1vCPU_2gb = Self.shared(vCPU: 1, memory: 2)
+    public static let shared_2vCPU_4gb = Self.shared(vCPU: 2, memory: 4)
 }
 
 extension DigitalOcean.App {

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -14,7 +14,7 @@ extension DigitalOcean {
             _ name: String,
             project: Project,
             targetName: String,
-            registry: ContainerRegistry,
+            registryName: String,
             region: Region = .nyc3,
             instancePort: Int = 8080,
             environment: [String: CustomStringConvertible]? = nil,
@@ -38,10 +38,10 @@ extension DigitalOcean {
                     "dockerfile": ["location": dockerFilePath],
                     "context": ["location": Context.projectDirectory],
                     "platforms": ["linux/\(architecture.dockerPlatform)"],
-                    "tags": ["\(registry.endpoint)/\(repository):latest"],
+                    "tags": ["registry.digitalocean.com/\(registryName)/\(repository):latest"],
                     "registries": [
                         [
-                            "address": registry.hostname,
+                            "address": "registry.digitalocean.com",
                             "username": digitalOceanToken,
                             "password": digitalOceanToken,
                         ]

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -74,9 +74,9 @@ extension DigitalOcean {
             )
 
             Context.current.store.build {
-                let dockerFile = Docker.Dockerfile.amazonLinux(targetName: targetName, port: instancePort)
+                let dockerFile = Docker.Dockerfile.ubuntu(targetName: targetName, port: instancePort)
                 try Docker.Dockerfile.write(dockerFile, to: dockerFilePath)
-                try await $0.builder.buildAmazonLinux(targetName: targetName, architecture: architecture)
+                try await $0.builder.buildUbuntu(targetName: targetName, architecture: architecture)
             }
         }
     }

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -77,7 +77,11 @@ extension DigitalOcean {
             )
 
             Context.current.store.build {
-                let dockerFile = Docker.Dockerfile.ubuntu(targetName: targetName, port: instancePort)
+                let dockerFile = Docker.Dockerfile.ubuntu(
+                    targetName: targetName,
+                    architecture: architecture,
+                    port: instancePort
+                )
                 try Docker.Dockerfile.write(dockerFile, to: dockerFilePath)
                 try await $0.builder.buildUbuntu(targetName: targetName, architecture: architecture)
             }

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -10,6 +10,14 @@ extension DigitalOcean {
             app.name
         }
 
+        public var hostname: Output<String> {
+            app.output.keyPath("liveDomain")
+        }
+
+        public var url: Output<String> {
+            app.output.keyPath("liveUrl")
+        }
+
         public init(
             _ name: String,
             project: Project,

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -1,0 +1,24 @@
+import CloudCore
+import Foundation
+
+extension DigitalOcean {
+    public struct App: DigitalOceanComponent {
+        public let service: Resource
+
+        public var name: Output<String> {
+            service.name
+        }
+
+        public init(
+            _ name: String,
+            options: Resource.Options? = nil
+        ) {
+            service = Resource(
+                name: name,
+                type: "digitalocean:App",
+                properties: [:],
+                options: options
+            )
+        }
+    }
+}

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -37,9 +37,8 @@ extension DigitalOcean {
                                 "name": tokenize(Context.current.stage, name, "service-0"),
                                 "dockerfilePath": dockerFilePath,
                                 "image": [
-                                    "registryType": "DOCR"
-                                        // "repository": tokenize(Context.current.stage, name, "repo"),
-                                        // "registryCredentials": ContainerRegistry.shared().credentials.dockerCredentials,
+                                    "registryType": "DOCR",
+                                    "repository": tokenize(Context.current.stage, name, "repo"),
                                 ],
                                 "httpPort": instancePort,
                             ]

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -2,23 +2,58 @@ import CloudCore
 import Foundation
 
 extension DigitalOcean {
-    public struct App: DigitalOceanComponent {
-        public let service: Resource
+    public struct App: DigitalOceanComponent, EnvironmentProvider {
+        public let app: Resource
+        public let environment: Environment
 
         public var name: Output<String> {
-            service.name
+            app.name
         }
 
         public init(
             _ name: String,
+            project: Project,
+            targetName: String,
+            region: Region = .nyc3,
+            instancePort: Int = 8080,
+            environment: [String: CustomStringConvertible]? = nil,
             options: Resource.Options? = nil
         ) {
-            service = Resource(
+            self.environment = Environment(environment, shape: .keyValueList)
+
+            let dockerFilePath = Docker.Dockerfile.filePath(name)
+
+            app = Resource(
                 name: name,
                 type: "digitalocean:App",
-                properties: [:],
+                properties: [
+                    "projectId": project.id,
+                    "spec": [
+                        "name": tokenize(Context.current.stage, name, "spec"),
+                        "region": region.rawValue,
+                        "envs": self.environment,
+                        "services": [
+                            [
+                                "name": tokenize(Context.current.stage, name, "service-0"),
+                                "dockerfilePath": dockerFilePath,
+                                "image": [
+                                    "registryType": "DOCR"
+                                        // "repository": tokenize(Context.current.stage, name, "repo"),
+                                        // "registryCredentials": ContainerRegistry.shared().credentials.dockerCredentials,
+                                ],
+                                "httpPort": instancePort,
+                            ]
+                        ],
+                    ],
+                ],
                 options: options
             )
+
+            Context.current.store.build {
+                let dockerFile = Docker.Dockerfile.amazonLinux(targetName: targetName, port: instancePort)
+                try Docker.Dockerfile.write(dockerFile, to: dockerFilePath)
+                try await $0.builder.buildAmazonLinux(targetName: targetName)
+            }
         }
     }
 }

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -84,7 +84,7 @@ extension DigitalOcean {
                                     [
                                         "minInstanceCount": $0.minimumConcurrency,
                                         "maxInstanceCount": $0.maximumConcurrency,
-                                        "metrics": ["cpu": $0.cpuTarget],
+                                        "metrics": ["cpu": ["percent": $0.cpuTarget]],
                                     ]
                                 } as Any?,
                             ]

--- a/Sources/CloudDigitalOcean/DigitalOcean.swift
+++ b/Sources/CloudDigitalOcean/DigitalOcean.swift
@@ -1,0 +1,3 @@
+@_exported import CloudCore
+
+public enum DigitalOcean {}

--- a/Sources/CloudDigitalOcean/DigitalOcean.swift
+++ b/Sources/CloudDigitalOcean/DigitalOcean.swift
@@ -1,3 +1,20 @@
 @_exported import CloudCore
 
 public enum DigitalOcean {}
+
+extension Project {
+
+    public func digitalOceanToken(
+        options: Resource.Options? = nil
+    ) -> String {
+        if let provider = options?.provider as? DigitalOcean.Provider, let token = provider.token {
+            return token
+        }
+        if let provider = providers.first(where: { $0.name == "digitalocean" }) {
+            if let token = provider.configuration["token"], let value = token {
+                return value
+            }
+        }
+        return Context.environment["DIGITALOCEAN_TOKEN"] ?? ""
+    }
+}

--- a/Sources/CloudDigitalOcean/DigitalOceanComponent.swift
+++ b/Sources/CloudDigitalOcean/DigitalOceanComponent.swift
@@ -1,0 +1,3 @@
+import CloudCore
+
+public protocol DigitalOceanComponent: Component {}

--- a/Sources/CloudDigitalOcean/DigitalOceanProject.swift
+++ b/Sources/CloudDigitalOcean/DigitalOceanProject.swift
@@ -1,0 +1,9 @@
+import CloudCore
+
+public protocol DigitalOceanProject: Project {}
+
+extension DigitalOceanProject {
+    public var providers: [Provider] {
+        [.digitalocean()]
+    }
+}

--- a/Sources/CloudDigitalOcean/DigitalOceanProvider.swift
+++ b/Sources/CloudDigitalOcean/DigitalOceanProvider.swift
@@ -2,12 +2,12 @@ import CloudCore
 
 extension Provider {
     public static func digitalocean(
-        apiKey: String? = nil
+        token: String? = nil
     ) -> Self {
         return .init(
             plugin: .digitalocean,
             configuration: [
-                "apiKey": apiKey
+                "token": token
             ],
             dependencies: []
         )
@@ -20,13 +20,13 @@ extension DigitalOcean {
 
         public init(
             _ name: String,
-            apiKey: String? = nil
+            token: String? = nil
         ) {
             resource = Resource(
                 name: name,
                 type: "pulumi:providers:digitalocean",
                 properties: [
-                    "apiKey": apiKey
+                    "token": token
                 ]
             )
         }

--- a/Sources/CloudDigitalOcean/DigitalOceanProvider.swift
+++ b/Sources/CloudDigitalOcean/DigitalOceanProvider.swift
@@ -18,10 +18,14 @@ extension DigitalOcean {
     public struct Provider: ResourceProvider {
         public let resource: Resource
 
+        public let token: String?
+
         public init(
             _ name: String,
             token: String? = nil
         ) {
+            self.token = token
+
             resource = Resource(
                 name: name,
                 type: "pulumi:providers:digitalocean",

--- a/Sources/CloudDigitalOcean/DigitalOceanProvider.swift
+++ b/Sources/CloudDigitalOcean/DigitalOceanProvider.swift
@@ -1,0 +1,34 @@
+import CloudCore
+
+extension Provider {
+    public static func digitalocean(
+        apiKey: String? = nil
+    ) -> Self {
+        return .init(
+            plugin: .digitalocean,
+            configuration: [
+                "apiKey": apiKey
+            ],
+            dependencies: []
+        )
+    }
+}
+
+extension DigitalOcean {
+    public struct Provider: ResourceProvider {
+        public let resource: Resource
+
+        public init(
+            _ name: String,
+            apiKey: String? = nil
+        ) {
+            resource = Resource(
+                name: name,
+                type: "pulumi:providers:digitalocean",
+                properties: [
+                    "apiKey": apiKey
+                ]
+            )
+        }
+    }
+}

--- a/Sources/CloudDigitalOcean/DigitalOceanResource.swift
+++ b/Sources/CloudDigitalOcean/DigitalOceanResource.swift
@@ -1,0 +1,5 @@
+import CloudCore
+
+public protocol DigitalOceanResourceProvider: ResourceProvider {}
+
+extension Resource: DigitalOceanResourceProvider {}

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -4,13 +4,21 @@ extension DigitalOcean {
     public struct ContainerRegistry: DigitalOceanResourceProvider {
         public let resource: Resource
 
+        public var endpoint: Output<String> {
+            resource.output.keyPath("endpoint")
+        }
+
+        public var hostname: Output<String> {
+            resource.output.keyPath("serverUrl")
+        }
+
         public var credentials: ContainerRegistryDockerCredentials {
             .init(resource.chosenName, registryName: resource.name, options: resource.options)
         }
 
         public init(
             _ name: String,
-            subscriptionTier: SubscriptionTier = .starter,
+            subscriptionTier: SubscriptionTier = .basic,
             region: Region = .nyc3,
             options: Resource.Options? = nil
         ) {

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -26,7 +26,6 @@ extension DigitalOcean {
                 name: name,
                 type: "digitalocean:ContainerRegistry",
                 properties: [
-                    "name": tokenize(Context.current.stage, name),
                     "subscriptionTierSlug": subscriptionTier.rawValue,
                     "region": region.rawValue,
                 ],

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -2,7 +2,7 @@ extension DigitalOcean {
     public struct ContainerRegistry: DigitalOceanResourceProvider {
         public let resource: Resource
 
-        var credentials: ContainerRegistryDockerCredentials {
+        public var credentials: ContainerRegistryDockerCredentials {
             .init(resource.chosenName, registryName: resource.name, options: resource.options)
         }
 

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -11,7 +11,7 @@ extension DigitalOcean {
         public init(
             _ name: String,
             subscriptionTier: SubscriptionTier = .starter,
-            region: String = "nyc3",
+            region: Region = .nyc3,
             options: Resource.Options? = nil
         ) {
             self.resource = .init(
@@ -20,7 +20,7 @@ extension DigitalOcean {
                 properties: [
                     "name": tokenize(Context.current.stage, name),
                     "subscriptionTierSlug": subscriptionTier.rawValue,
-                    "region": region,
+                    "region": region.rawValue,
                 ],
                 options: options
             )

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -35,3 +35,13 @@ extension DigitalOcean.ContainerRegistry {
         case professional
     }
 }
+
+extension DigitalOcean.ContainerRegistry {
+    public static func shared(options: Resource.Options? = nil) -> Self {
+        let suffix = options?.provider.map { $0.resource.chosenName } ?? ""
+        return .init(
+            "shared-image-repository-\(suffix)",
+            options: .provider(options?.provider)
+        )
+    }
+}

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -1,3 +1,5 @@
+import CloudCore
+
 extension DigitalOcean {
     public struct ContainerRegistry: DigitalOceanResourceProvider {
         public let resource: Resource
@@ -9,13 +11,16 @@ extension DigitalOcean {
         public init(
             _ name: String,
             subscriptionTier: SubscriptionTier = .starter,
+            region: String = "nyc3",
             options: Resource.Options? = nil
         ) {
             self.resource = .init(
                 name: name,
                 type: "digitalocean:ContainerRegistry",
                 properties: [
-                    "subscriptionTierSlug": subscriptionTier.rawValue
+                    "name": tokenize(Context.current.stage, name),
+                    "subscriptionTierSlug": subscriptionTier.rawValue,
+                    "region": region,
                 ],
                 options: options
             )

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistry.swift
@@ -1,0 +1,32 @@
+extension DigitalOcean {
+    public struct ContainerRegistry: DigitalOceanResourceProvider {
+        public let resource: Resource
+
+        var credentials: ContainerRegistryDockerCredentials {
+            .init(resource.chosenName, registryName: resource.name, options: resource.options)
+        }
+
+        public init(
+            _ name: String,
+            subscriptionTier: SubscriptionTier = .starter,
+            options: Resource.Options? = nil
+        ) {
+            self.resource = .init(
+                name: name,
+                type: "digitalocean:ContainerRegistry",
+                properties: [
+                    "subscriptionTierSlug": subscriptionTier.rawValue
+                ],
+                options: options
+            )
+        }
+    }
+}
+
+extension DigitalOcean.ContainerRegistry {
+    public enum SubscriptionTier: String {
+        case starter
+        case basic
+        case professional
+    }
+}

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
@@ -13,7 +13,7 @@ extension DigitalOcean {
         ) {
             self.resource = .init(
                 name: "\(name)-docker-credentials",
-                type: "digitalocean:ContainerRegistry",
+                type: "digitalocean:ContainerRegistryDockerCredentials",
                 properties: [
                     "registryName": registryName
                 ],

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
@@ -1,0 +1,24 @@
+extension DigitalOcean {
+    public struct ContainerRegistryDockerCredentials: DigitalOceanResourceProvider {
+        public let resource: Resource
+
+        var dockerCredentials: Output<String> {
+            resource.output.keyPath("dockerCredentials")
+        }
+
+        public init(
+            _ name: String,
+            registryName: Output<String>,
+            options: Resource.Options? = nil
+        ) {
+            self.resource = .init(
+                name: "\(name)-docker-credentials",
+                type: "digitalocean:ContainerRegistry",
+                properties: [
+                    "registryName": registryName
+                ],
+                options: options
+            )
+        }
+    }
+}

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
@@ -15,7 +15,8 @@ extension DigitalOcean {
                 name: "\(name)-docker-credentials",
                 type: "digitalocean:ContainerRegistryDockerCredentials",
                 properties: [
-                    "registryName": registryName
+                    "registryName": registryName,
+                    "write": true,
                 ],
                 options: options
             )

--- a/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
+++ b/Sources/CloudDigitalOcean/Resources/ContainerRegistryDockerCredentials.swift
@@ -2,7 +2,7 @@ extension DigitalOcean {
     public struct ContainerRegistryDockerCredentials: DigitalOceanResourceProvider {
         public let resource: Resource
 
-        var dockerCredentials: Output<String> {
+        public var dockerCredentials: Output<String> {
             resource.output.keyPath("dockerCredentials")
         }
 

--- a/Sources/CloudDigitalOcean/Resources/Project.swift
+++ b/Sources/CloudDigitalOcean/Resources/Project.swift
@@ -1,0 +1,29 @@
+extension DigitalOcean {
+    public struct Project: DigitalOceanResourceProvider {
+        public let resource: Resource
+
+        public init(
+            _ name: String,
+            environment: Environment = Context.current.isProduction ? .production : .development,
+            options: Resource.Options? = nil
+        ) {
+            self.resource = .init(
+                name: name,
+                type: "digitalocean:Project",
+                properties: [
+                    "environment": environment.rawValue,
+                    "description": "Managed by Swift Cloud",
+                ],
+                options: options
+            )
+        }
+    }
+}
+
+extension DigitalOcean.Project {
+    public enum Environment: String {
+        case development = "Development"
+        case staging = "Staging"
+        case production = "Production"
+    }
+}

--- a/Sources/CloudDigitalOcean/Resources/Project.swift
+++ b/Sources/CloudDigitalOcean/Resources/Project.swift
@@ -11,6 +11,7 @@ extension DigitalOcean {
                 name: name,
                 type: "digitalocean:Project",
                 properties: [
+                    "name": tokenize(Context.current.stage, name),
                     "environment": environment.rawValue,
                     "description": "Managed by Swift Cloud",
                 ],

--- a/Sources/CloudDigitalOcean/Resources/Region.swift
+++ b/Sources/CloudDigitalOcean/Resources/Region.swift
@@ -1,0 +1,39 @@
+extension DigitalOcean {
+    public enum Region: String {
+        case nyc1
+        case nyc2
+        case nyc3
+        case ams3
+        case sfo2
+        case sfo3
+        case sgp1
+        case lon1
+        case fra1
+        case tor1
+        case blr1
+        case syd1
+
+        var description: String {
+            switch self {
+            case .nyc1, .nyc2, .nyc3:
+                return "New York City, United States"
+            case .ams3:
+                return "Amsterdam, the Netherlands"
+            case .sfo2, .sfo3:
+                return "San Francisco, United States"
+            case .sgp1:
+                return "Singapore"
+            case .lon1:
+                return "London, United Kingdom"
+            case .fra1:
+                return "Frankfurt, Germany"
+            case .tor1:
+                return "Toronto, Canada"
+            case .blr1:
+                return "Bangalore, India"
+            case .syd1:
+                return "Sydney, Australia"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for deploying Swift applications to DigitalOcean:


```swift
import Cloud

@main
struct SwiftCloudDemo: Project {
    func build() async throws -> Outputs {
        let project = DigitalOcean.Project("MyProject")

        let app = DigitalOcean.App(
            "MyApp",
            project: project,
            targetName: "hummingbird-server",
            registryName: "swift-cloud-demo"
        )

        return [
            "app": app.url,
        ]
    }
}
```