### PR TITLE
Fix DynamoDB creation with Global Secondary Indexes

### DIFF
--- a/Sources/CloudAWS/Components/DynamoDB.swift
+++ b/Sources/CloudAWS/Components/DynamoDB.swift
@@ -36,10 +36,7 @@ extension AWS {
                     "billingMode": "PAY_PER_REQUEST",
                     "hashKey": primaryIndex.partitionKey.name,
                     "rangeKey": primaryIndex.sortKey?.name,
-                    "attributes": [
-                        ["name": primaryIndex.partitionKey.name, "type": primaryIndex.partitionKey.type.rawValue],
-                        primaryIndex.sortKey.map { ["name": $0.name, "type": $0.type.rawValue] },
-                    ].compactMap { $0 },
+                    "attributes": ([primaryIndex] + secondaryIndexes).asAttributes,
                     "globalSecondaryIndexes": secondaryIndexes.map { index in
                         [
                             "name": index.partitionKey.name,
@@ -181,5 +178,20 @@ extension AWS.DynamoDB: Linkable {
                 "name": name
             ]
         )
+    }
+}
+
+private extension AWS.DynamoDB.Index {
+    var asAttributes: [[String: String]] {
+        [
+            ["name": partitionKey.name, "type": partitionKey.type.rawValue],
+            sortKey.map { ["name": $0.name, "type": $0.type.rawValue] },
+        ].compactMap { $0 }
+    }
+}
+
+private extension [AWS.DynamoDB.Index] {
+    var asAttributes: [[String: String]] {
+        flatMap(\.asAttributes)
     }
 }


### PR DESCRIPTION
Per the [docs here](https://www.pulumi.com/registry/packages/aws/api-docs/dynamodb/table/), the secondary indexes need to be added to the attributes parameter as well.

This PR fixes it.