### PR TITLE
Fix secondary indexes permissions on DynamoDB

### DIFF
--- a/Sources/CloudAWS/Components/DynamoDB.swift
+++ b/Sources/CloudAWS/Components/DynamoDB.swift
@@ -168,7 +168,11 @@ extension AWS.DynamoDB: Linkable {
     }
 
     public var resources: [Output<String>] {
-        [table.arn, streamArn].compactMap { $0 }
+        [
+            table.arn,
+            "\(table.arn)/*",
+            streamArn
+        ].compactMap { $0 }
     }
 
     public var properties: LinkProperties? {


### PR DESCRIPTION
By adding the table subresources ARN’s. See more here: https://github.com/pulumi/pulumi-aws/issues/1987