### PR TITLE
Fix VercelDNS

### DIFF
--- a/Sources/CloudVercel/VercelDNS.swift
+++ b/Sources/CloudVercel/VercelDNS.swift
@@ -25,7 +25,7 @@ extension Vercel {
                 name: name,
                 value: target,
                 ttl: ttl,
-                teamId: teamId,
+                teamId: teamId
             )
         }
 


### PR DESCRIPTION
Fixes a syntax error in `VercelDNS.swift` by removing a trailing comma in the `createRecord` method, resolving an unresolved error.