### PR TITLE
Add support for Swift 6.2

### DIFF
--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -48,7 +48,9 @@ extension Builder {
                 imageName = "swift:6.0-amazonlinux2"
             case "6.1":
                 imageName = "swift:6.1-amazonlinux2"
-            default:
+            case "6.2":
+                imageName = "swift:nightly-6.2-amazonlinux2"
+            default: 
                 fatalError("Unsupported Swift version: \(swiftVersion)")
             }
             try await buildDocker(
@@ -72,6 +74,8 @@ extension Builder {
             imageName = "swift:6.0-noble"
         case "6.1":
             imageName = "swift:6.1-noble"
+        case "6.2":
+            imageName = "swift:nightly-6.2-noble"
         default:
             fatalError("Unsupported Swift version: \(swiftVersion)")
         }
@@ -106,6 +110,11 @@ extension Builder {
             flags = ["--swift-sdk", "wasm32-unknown-wasi"]
             pre =
                 "swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992"
+        case "6.2":
+            imageName = "swift:nightly-6.2"
+            flags = ["--swift-sdk", "wasm32-unknown-wasi"]
+            pre =
+                "swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a-wasm32-unknown-wasi.artifactbundle.zip --checksum 37516de837411ea46e4f9e75d52bd742f6941febac49981aac0c4f20f02b8b54"
         default:
             fatalError("Unsupported Swift version: \(swiftVersion)")
         }


### PR DESCRIPTION
This pull request adds support for Swift 6.2 in the `Builder.swift` by updating the Docker image names and SDK installation for Swift 6.2. Changes include:
- Added `swift:nightly-6.2-amazonlinux2` and `swift:nightly-6.2-noble` for respective platforms.
- Included Swift 6.2 WebAssembly SDK with updated checksum.

> No breaking changes; ensures compatibility with Swift 6.2.

**Swift 6.2 is still in nightly/development, I'm keeping this PR in draft for now.** 