### PR TITLE
Fix CloudflareDNS

### DIFF
--- a/Sources/CloudCloudflare/Functions/GetZone.swift
+++ b/Sources/CloudCloudflare/Functions/GetZone.swift
@@ -1,21 +1,83 @@
 extension Cloudflare {
     public struct GetZone {
-        public let accountId: String
+        public let account: GetZoneAccount
+        public let activatedOn: String
+        public let cnameSuffix: String
+        public let createdOn: String
+        public let developmentMode: Int
+        public let id: String
+        public let meta: GetZoneMeta
+        public let modifiedOn: String
+        public let name: String
+        public let nameServers: [String]
+        public let originalDnshost: String
+        public let originalNameServers: [String]
+        public let originalRegistrar: String
+        public let owner: GetZoneOwner
+        public let paused: Bool
+        public let permissions: [String]
+        public let plan: GetZonePlan
+        public let status: String
+        public let tenant: GetZoneTenant
+        public let tenantUnit: GetZoneTenantUnit
+        public let type: String
+        public let vanityNameServers: [String]
+        public let verificationKey: String
+        public let zoneId: String?
+    }
+
+    public struct GetZoneAccount {
         public let id: String
         public let name: String
-        public let nameServers: [String]?
-        public let paused: Bool
-        public let plan: String
-        public let status: String
-        public let vanityNameServers: [String]?
-        public let zoneId: String
+    }
+
+    public struct GetZoneMeta {
+        public let cdnOnly: Bool
+        public let customCertificateQuota: Int
+        public let dnsOnly: Bool
+        public let foundationDns: Bool
+        public let pageRuleQuota: Int
+        public let phishingDetected: Bool
+        public let step: Int
+    }
+
+    public struct GetZoneOwner {
+        public let id: String
+        public let name: String
+        public let type: String
+    }
+
+    public struct GetZonePlan {
+        public let canSubscribe: Bool
+        public let currency: String
+        public let externallyManaged: Bool
+        public let frequency: String
+        public let id: String
+        public let isSubscribed: Bool
+        public let legacyDiscount: Bool
+        public let legacyId: String
+        public let name: String
+        public let price: Int
+    }
+
+    public struct GetZoneTenant {
+        public let id: String
+        public let name: String
+    }
+
+    public struct GetZoneTenantUnit {
+        public let id: String
     }
 
     public static func getZone(name: any Input<String>) -> Output<GetZone> {
         let variable = Variable<GetZone>.invoke(
             name: "\(name)-zone",
             function: "cloudflare:getZone",
-            arguments: ["name": name]
+            arguments: [
+                "filter": [
+                    "name": name
+                ]
+            ]
         )
         return variable.output
     }
@@ -24,7 +86,9 @@ extension Cloudflare {
         let variable = Variable<GetZone>.invoke(
             name: "\(zoneId)-zone",
             function: "cloudflare:getZone",
-            arguments: ["zoneId": zoneId]
+            arguments: [
+                "zoneId": zoneId
+            ]
         )
         return variable.output
     }

--- a/Sources/CloudCloudflare/Resources/DNSRecord.swift
+++ b/Sources/CloudCloudflare/Resources/DNSRecord.swift
@@ -3,7 +3,7 @@ extension Cloudflare {
         public let resource: Resource
 
         public var fqdn: Output<String> {
-            resource.output.keyPath("hostname")
+            resource.output.keyPath("name")
         }
 
         public init(
@@ -19,15 +19,14 @@ extension Cloudflare {
             let zone = getZone(name: zoneName)
             resource = Resource(
                 name: "\(zoneName)-\(name)-\(type)-record",
-                type: "cloudflare:Record",
+                type: "cloudflare:DnsRecord",
                 properties: [
-                    "zoneId": zone.id,
+                    "zoneId": zone.zoneId,
                     "type": type,
                     "name": Strings.trimSuffix(name, suffix: ".\(zoneName)").result,
                     "content": value,
                     "proxied": proxied,
                     "ttl": proxied ? 1 : ttl.components.seconds,
-                    "allowOverwrite": true,
                     "comment": "Managed by Swift Cloud",
                 ],
                 options: options,


### PR DESCRIPTION
This pull request updates the Cloudflare to match the latest Pulumi provider changes.

* Migrated the `DNSRecord` resource from the deprecated `cloudflare:Record` to the recommended `cloudflare:DnsRecord`, in line with Pulumi Cloudflare provider updates.
* Updated FQDN resolution to reference the `name` property instead of the deprecated `hostname`.
* Removed the `allowOverwrite` property, which is no longer supported in the updated schema.

These changes fixes the following issues:

```
Warning: name does not exist on Invoke cloudflare:index/getZone:getZone
Existing fields are: filter, zoneId

Error: Property allowOverwrite does not exist on 'cloudflare:index/record:Record'
Cannot assign '{allowOverwrite: boolean, ...}' to 'cloudflare:index/record:Record'
Existing properties are: priority, comment, content, proxied, zoneId and 6 others

Error: hostname does not exist on dev-dewonderstruck-com-dev-oauth-dewonderstruck-co-c641
Existing properties are: name, content, data, meta, tags and 14 others
```

**Reference:**
[Pulumi Cloudflare Registry – DnsRecord](https://www.pulumi.com/registry/packages/cloudflare/api-docs/dnsrecord/)