### PR TITLE
Fix Environment

### DIFF
--- a/Sources/CloudAWS/Components/WebServer.swift
+++ b/Sources/CloudAWS/Components/WebServer.swift
@@ -69,7 +69,7 @@ extension AWS {
             autoScaling: AutoScalingConfiguration? = nil,
             instancePort: Int = 8080,
             vpc: AWS.VPC? = nil,
-            environment: [String: String] = [:],
+            environment: [String: any Input<String>] = [:],
             options: Resource.Options? = nil,
             context: Context = .current
         ) {

--- a/Sources/CloudCore/Environment.swift
+++ b/Sources/CloudCore/Environment.swift
@@ -50,10 +50,10 @@ public final class Environment: Encodable, @unchecked Sendable {
         case .keyValue:
             try container.encode(store.reduce(into: [:]) { $0[$1.key] = "\($1.value)" })
         case .keyValueList:
-            let pairs = store.map { KeyValuePair(key: $0.key, value: "\($0)") }
+            let pairs = store.map { KeyValuePair(key: $0.key, value: "\($0.value)") }
             try container.encode(pairs)
         case .nameValueList:
-            let pairs = store.map { NameValuePair(name: $0.key, value: "\($0)") }
+            let pairs = store.map { NameValuePair(name: $0.key, value: "\($0.value)") }
             try container.encode(pairs)
         }
     }


### PR DESCRIPTION
Fixes env variables encoding to use actual values instead of tuple strings for AWS ECS Fargate.

**Before:**  
```json
[{"name": "OAUTH_TESTING_MODE", "value": "{ key: OAUTH_TESTING_MODE, value: \"false\"}"}]
```

**After:**  
```json
[{"name": "OAUTH_TESTING_MODE", "value": "false"}]
```