### PR TITLE
Fix Vapor Docker Build with Custom Arguments Support

### DIFF
--- a/Sources/CloudAWS/Components/WebServer.swift
+++ b/Sources/CloudAWS/Components/WebServer.swift
@@ -70,6 +70,7 @@ extension AWS {
             instancePort: Int = 8080,
             vpc: AWS.VPC? = nil,
             environment: [String: any Input<String>] = [:],
+            arguments: [String]? = nil,
             options: Resource.Options? = nil,
             context: Context = .current
         ) {
@@ -197,7 +198,19 @@ extension AWS {
             domainName?.aliasTo(internalHostname)
 
             context.store.build {
-                let dockerFile = Docker.Dockerfile.ubuntu(targetName: targetName, port: instancePort)
+                let dockerFile: String
+                if let arguments = arguments {
+                    dockerFile = Docker.Dockerfile.ubuntu(
+                        targetName: targetName,
+                        port: instancePort,
+                        arguments: arguments
+                    )
+                } else {
+                    dockerFile = Docker.Dockerfile.ubuntu(
+                        targetName: targetName,
+                        port: instancePort
+                    )
+                }
                 try Docker.Dockerfile.write(dockerFile, to: dockerFilePath)
                 try await $0.builder.buildUbuntu(targetName: targetName)
             }

--- a/Sources/CloudCore/Docker/Docker.swift
+++ b/Sources/CloudCore/Docker/Docker.swift
@@ -33,8 +33,30 @@ extension Docker.Dockerfile {
         """
     }
 
-    public static func amazonLinux(targetName: String, architecture: Architecture = .current, port: Int) -> String {
-        """
+    public static func amazonLinux(
+        targetName: String,
+        architecture: Architecture = .current,
+        port: Int
+    ) -> String {
+        amazonLinux(
+            targetName: targetName,
+            architecture: architecture,
+            port: port,
+            arguments: ["--hostname", "0.0.0.0", "--port", "\(port)"]
+        )
+    }
+
+    public static func amazonLinux(
+        targetName: String,
+        architecture: Architecture = .current,
+        port: Int,
+        arguments: [String]
+    ) -> String {
+        let commandArguments = arguments
+            .map { "\"\($0)\"" }
+            .joined(separator: ", ")
+
+        return """
         FROM amazonlinux:2
 
         WORKDIR /app/
@@ -53,12 +75,34 @@ extension Docker.Dockerfile {
         EXPOSE \(port)
 
         ENTRYPOINT [ "./\(targetName)" ]
-        CMD ["--hostname", "0.0.0.0", "--port", "\(port)"]
+        CMD [\(commandArguments)]
         """
     }
 
-    public static func ubuntu(targetName: String, architecture: Architecture = .current, port: Int) -> String {
-        """
+    public static func ubuntu(
+        targetName: String,
+        architecture: Architecture = .current,
+        port: Int
+    ) -> String {
+        ubuntu(
+            targetName: targetName,
+            architecture: architecture,
+            port: port,
+            arguments: ["--hostname", "0.0.0.0", "--port", "\(port)"]
+        )
+    }
+
+    public static func ubuntu(
+        targetName: String,
+        architecture: Architecture = .current,
+        port: Int,
+        arguments: [String]
+    ) -> String {
+        let commandArguments = arguments
+            .map { "\"\($0)\"" }
+            .joined(separator: ", ")
+
+        return """
         FROM ubuntu:noble
 
         RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -86,7 +130,7 @@ extension Docker.Dockerfile {
         EXPOSE \(port)
 
         ENTRYPOINT [ "./\(targetName)" ]
-        CMD ["--hostname", "0.0.0.0", "--port", "\(port)"]
+        CMD [\(commandArguments)]
         """
     }
 }

--- a/Sources/CloudCore/Docker/Docker.swift
+++ b/Sources/CloudCore/Docker/Docker.swift
@@ -16,6 +16,12 @@ extension Docker.Dockerfile {
 }
 
 extension Docker.Dockerfile {
+    private static func formatCommandArguments(_ arguments: [String]) -> String {
+        arguments
+            .map { "\"\($0)\"" }
+            .joined(separator: ", ")
+    }
+    
     public static func awsLambda(targetName: String, architecture: Architecture = .current) -> String {
         """
         FROM public.ecr.aws/lambda/provided:al2
@@ -52,9 +58,7 @@ extension Docker.Dockerfile {
         port: Int,
         arguments: [String]
     ) -> String {
-        let commandArguments = arguments
-            .map { "\"\($0)\"" }
-            .joined(separator: ", ")
+        let commandArguments = formatCommandArguments(arguments)
 
         return """
         FROM amazonlinux:2
@@ -98,9 +102,7 @@ extension Docker.Dockerfile {
         port: Int,
         arguments: [String]
     ) -> String {
-        let commandArguments = arguments
-            .map { "\"\($0)\"" }
-            .joined(separator: ", ")
+        let commandArguments = formatCommandArguments(arguments)
 
         return """
         FROM ubuntu:noble

--- a/Sources/CloudDigitalOcean/Components/App.swift
+++ b/Sources/CloudDigitalOcean/Components/App.swift
@@ -27,6 +27,7 @@ extension DigitalOcean {
             instanceSize: InstanceSize = .shared_1vCPU_512mb,
             instancePort: Int = 8080,
             environment: [String: any Input<String>]? = nil,
+            arguments: [String]? = nil,
             options: Resource.Options? = nil,
             context: Context = .current
         ) {
@@ -99,11 +100,21 @@ extension DigitalOcean {
             )
 
             context.store.build {
-                let dockerFile = Docker.Dockerfile.ubuntu(
-                    targetName: targetName,
-                    architecture: architecture,
-                    port: instancePort
-                )
+                let dockerFile: String
+                if let arguments = arguments {
+                    dockerFile = Docker.Dockerfile.ubuntu(
+                        targetName: targetName,
+                        architecture: architecture,
+                        port: instancePort,
+                        arguments: arguments
+                    )
+                } else {
+                    dockerFile = Docker.Dockerfile.ubuntu(
+                        targetName: targetName,
+                        architecture: architecture,
+                        port: instancePort
+                    )
+                }
                 try Docker.Dockerfile.write(dockerFile, to: dockerFilePath)
                 try await $0.builder.buildUbuntu(targetName: targetName, architecture: architecture)
             }


### PR DESCRIPTION
This pull request adds support for custom command-line arguments in the Vapor Docker build process for AWS and DigitalOcean deployments, fixing issues with hardcoded CMD.

- Fix Vapor 4 Docker build issue where hardcoded CMD arguments `["--hostname", "0.0.0.0", "--port", "\(port)"]` were causing deployment failures

```swift
let environment: [String: any Input<String>] = [
    "OAUTH_TESTING_MODE": "false"
]

let server = AWS.WebServer(
    "vapor-web-server",
    targetName: "App",
    domainName: .init(
        hostname: "api.example.com",
        dns: .cloudflare(zoneName: "example.com")
    ),
    environment: environment,
    arguments: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "8080"]
)
```