### PR TITLE
Add ACM certificate acquisition with domain lookup and certificate reuse

### DIFF
--- a/Sources/CloudAWS/Functions/ACM/ACMGetCertificate.swift
+++ b/Sources/CloudAWS/Functions/ACM/ACMGetCertificate.swift
@@ -1,0 +1,20 @@
+extension AWS {
+    public struct GetCertificate {
+        public let arn: String?
+        public let status: String?
+        public let domainName: String
+    }
+
+    public static func getCertificate(domainName: any Input<String>) -> Output<GetCertificate?> {
+        let variable = Variable<GetCertificate?>.invoke(
+            name: "\(domainName)-existing-cert",
+            function: "aws:acm:getCertificate",
+            arguments: [
+                "domain": domainName,
+                "mostRecent": true,
+                "statuses": ["ISSUED"]
+            ]
+        )
+        return variable.output
+    }
+}

--- a/Sources/CloudAWS/Resources/TLSCertificate.swift
+++ b/Sources/CloudAWS/Resources/TLSCertificate.swift
@@ -84,6 +84,22 @@ extension AWS {
             }
             return Output(prefix: "null", root: "", path: [])
         }
+        
+        /// Returns existing certificate if found, otherwise creates new one
+        public static func getOrCreate(
+            hostname: any Input<String>,
+            keyAlgorithm: KeyAlgorithm = .ecdsa,
+            options: Resource.Options? = nil,
+            context: Context = .current
+        ) -> TLSCertificate {
+            return TLSCertificate(
+                hostname: hostname,
+                keyAlgorithm: keyAlgorithm,
+                reuseExisting: true,
+                options: options,
+                context: context
+            )
+        }
     }
 }
 

--- a/Sources/CloudAWS/Resources/TLSCertificate.swift
+++ b/Sources/CloudAWS/Resources/TLSCertificate.swift
@@ -1,6 +1,8 @@
 extension AWS {
     public struct TLSCertificate: AWSResourceProvider {
         public let resource: Resource
+        public let arn: Output<String>
+        private let existingCertLookup: Variable<GetCertificate?>?
 
         public var domainValidationOptions:
             Output<[(resourceRecordName: String, resourceRecordType: String, resourceRecordValue: String)]>
@@ -9,26 +11,78 @@ extension AWS {
         }
 
         public var status: Output<String> {
-            resource.output.keyPath("status")
+            return resource.output.keyPath("status")
         }
 
         public init(
             hostname: any Input<String>,
             keyAlgorithm: KeyAlgorithm = .ecdsa,
+            reuseExisting: Bool = true,
             options: Resource.Options? = nil,
             context: Context = .current
         ) {
-            resource = Resource(
-                name: "\(hostname)-cert",
-                type: "aws:acm:Certificate",
-                properties: [
-                    "domainName": hostname,
-                    "keyAlgorithm": keyAlgorithm.rawValue,
-                    "validationMethod": "DNS",
-                ],
-                options: options,
-                context: context
-            )
+            if reuseExisting {
+                // Look for existing certificate
+                self.existingCertLookup = Variable<GetCertificate?>.invoke(
+                    name: "\(hostname)-cert-lookup",
+                    function: "aws:acm:getCertificate",
+                    arguments: [
+                        "domain": hostname,
+                        "mostRecent": true,
+                        "statuses": ["ISSUED"]
+                    ]
+                )
+                
+                // Create the certificate resource
+                // Pulumi will handle conflicts by showing import suggestions
+                resource = Resource(
+                    name: "\(hostname)-cert",
+                    type: "aws:acm:Certificate",
+                    properties: [
+                        "domainName": hostname,
+                        "keyAlgorithm": keyAlgorithm.rawValue,
+                        "validationMethod": "DNS",
+                    ],
+                    options: options,
+                    context: context
+                )
+                
+                self.arn = resource.output.keyPath("arn")
+            } else {
+                self.existingCertLookup = nil
+                
+                // Always create new certificate
+                resource = Resource(
+                    name: "\(hostname)-cert",
+                    type: "aws:acm:Certificate",
+                    properties: [
+                        "domainName": hostname,
+                        "keyAlgorithm": keyAlgorithm.rawValue,
+                        "validationMethod": "DNS",
+                    ],
+                    options: options,
+                    context: context
+                )
+                
+                self.arn = resource.output.keyPath("arn")
+            }
+        }
+        
+        /// Check if an existing certificate was found for this domain
+        public var hasExistingCertificate: Output<Bool> {
+            if let existingCertLookup {
+                return existingCertLookup.output.keyPath("arn")
+            }
+            return Output(prefix: "false", root: "", path: [])
+        }
+        
+        /// Get the existing certificate ARN if available  
+        /// This can be used to conditionally skip DNS validation if certificate already exists
+        public var existingCertificateArn: Output<String?> {
+            if let existingCertLookup {
+                return existingCertLookup.output.keyPath("arn")
+            }
+            return Output(prefix: "null", root: "", path: [])
         }
     }
 }


### PR DESCRIPTION
This pull request adds domain lookup and certificate reuse, fixing the Cloudflare DNS challenge issue where if the DNS record already exists by avoiding redundant certificate requests.