### PR TITLE
Minor README.md change about domain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ The `DomainName` construct manages a TLS certificate and the necessary
 validation, and can be linked to a `WebServer` to provide a fully managed domain
 name.
 
-> Important: We support 3 providers for domains: `AWS`, `Cloudflare`, and
-> `Vercel`.
+> [!IMPORTANT]
+> SwiftCloud supports 3 providers for domains: **AWS**, **Cloudflare**, and **Vercel**.
 
 ```swift
 let domainName = DomainName(


### PR DESCRIPTION
This PR changes the quote syntax to use the [alert syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):

<img width="1200" height="188" alt="Arc-2025-09-21 at 14 31 25@2x" src="https://github.com/user-attachments/assets/298ae2e9-eaf4-4de5-afa6-2cfec4ae0077" />
