### PR TITLE
Switch to Stable Swift 6.2 Docker Images

### DIFF
--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -49,7 +49,7 @@ extension Builder {
             case "6.1":
                 imageName = "swift:6.1-amazonlinux2"
             case "6.2":
-                imageName = "swiftlang/swift:nightly-6.2-amazonlinux2"
+                imageName = "swift:6.2-amazonlinux2"
             default:
                 fatalError("Unsupported Swift version: \(swiftVersion)")
             }
@@ -75,7 +75,7 @@ extension Builder {
         case "6.1":
             imageName = "swift:6.1-noble"
         case "6.2":
-            imageName = "swiftlang/swift:nightly-6.2-noble"
+            imageName = "swift:6.2-noble"
         default:
             fatalError("Unsupported Swift version: \(swiftVersion)")
         }
@@ -111,10 +111,10 @@ extension Builder {
             pre =
                 "swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992"
         case "6.2":
-            imageName = "swiftlang/swift:nightly-6.2"
+            imageName = "swift:6.2.0"
             flags = ["--swift-sdk", "wasm32-unknown-wasi"]
             pre =
-                "swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasi.artifactbundle.zip --checksum 249e8fc0dd6bc5e31583d6c63c778830ff0e3b9f98cff7ee6b31b2decf5f87cb"
+                "swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.2-RELEASE/swift-wasm-6.2-RELEASE-wasm32-unknown-wasip1.artifactbundle.zip --checksum f206a9ff2352f726d88a59d2241b9581264326471265229b7ffd133d2593b92b"
         default:
             fatalError("Unsupported Swift version: \(swiftVersion)")
         }


### PR DESCRIPTION
This PR updates the Docker image references and SDK installation commands in `Sources/CloudCore/Builder.swift` to use stable Swift 6.2 releases instead of nightly builds.