### PR TITLE
Add S3 bucket CORS support with origin validation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -78,5 +78,9 @@ let package = Package(
             name: "CloudCoreTests",
             dependencies: ["CloudCore"]
         ),
+        .testTarget(
+            name: "CloudAWSTests",
+            dependencies: ["CloudAWS"]
+        ),
     ]
 )

--- a/Sources/CloudAWS/Components/Bucket.swift
+++ b/Sources/CloudAWS/Components/Bucket.swift
@@ -6,19 +6,19 @@ extension AWS {
         internal let ownershipControls: Resource
         internal let publicAccessBlock: Resource
         internal let corsConfiguration: Resource?
-        
+
         public var name: Output<String> {
             bucket.id
         }
-        
+
         public var region: Output<String> {
             getARN(bucket).region
         }
-        
+
         public var hostname: Output<String> {
             bucket.output.keyPath("bucketRegionalDomainName")
         }
-        
+
         public init(
             _ name: String,
             cors: [CORSRule]? = nil,
@@ -35,7 +35,7 @@ extension AWS {
                 options: options,
                 context: context
             )
-            
+
             ownershipControls = Resource(
                 name: "\(name)-oc",
                 type: "aws:s3:BucketOwnershipControls",
@@ -48,7 +48,7 @@ extension AWS {
                 options: options,
                 context: context
             )
-            
+
             publicAccessBlock = Resource(
                 name: "\(name)-pab",
                 type: "aws:s3:BucketPublicAccessBlock",
@@ -59,7 +59,7 @@ extension AWS {
                 options: options,
                 context: context
             )
-            
+
             if let cors {
                 corsConfiguration = Resource(
                     name: "\(name)-cors",
@@ -107,7 +107,7 @@ extension AWS.Bucket {
         public var allowedHeaders: [String]
         public var exposeHeaders: [String]
         public var maxAgeSeconds: Int?
-        
+
         public init(
             allowedMethods: [HTTPMethod] = [.get, .head],
             allowedOrigins: [String] = ["*"],
@@ -124,7 +124,7 @@ extension AWS.Bucket {
             self.exposeHeaders = exposeHeaders
             self.maxAgeSeconds = maxAgeSeconds
         }
-        
+
         private static func validateOrigin(_ origin: String) {
             guard isValidOrigin(origin) else {
                 fatalError(
@@ -132,21 +132,22 @@ extension AWS.Bucket {
                 )
             }
         }
-        
+
         internal static func isValidOrigin(_ origin: String) -> Bool {
             guard origin != "*" else { return true }
-            
+
             guard let url = URL(string: origin),
-                  let scheme = url.scheme,
-                  (scheme == "http" || scheme == "https"),
-                  let host = url.host,
-                  !host.isEmpty,
-                  url.path == "/" || url.path.isEmpty,
-                  url.query == nil,
-                  url.fragment == nil else {
+                let scheme = url.scheme,
+                scheme == "http" || scheme == "https",
+                let host = url.host,
+                !host.isEmpty,
+                url.path == "/" || url.path.isEmpty,
+                url.query == nil,
+                url.fragment == nil
+            else {
                 return false
             }
-            
+
             return true
         }
     }
@@ -161,14 +162,14 @@ extension AWS.Bucket: Linkable {
             "s3:ListBucket",
         ]
     }
-    
+
     public var resources: [Output<String>] {
         [
             "\(bucket.arn)",
             "\(bucket.arn)/*",
         ]
     }
-    
+
     public var properties: LinkProperties? {
         return .init(
             type: "bucket",

--- a/Sources/CloudAWS/Components/Bucket.swift
+++ b/Sources/CloudAWS/Components/Bucket.swift
@@ -1,4 +1,3 @@
-import NIOHTTP1
 import Foundation
 
 extension AWS {
@@ -96,6 +95,13 @@ extension AWS {
 
 extension AWS.Bucket {
     public struct CORSRule {
+        public enum HTTPMethod: String {
+            case get = "GET"
+            case put = "PUT"
+            case post = "POST"
+            case delete = "DELETE"
+            case head = "HEAD"
+        }
         public var allowedMethods: [HTTPMethod]
         public var allowedOrigins: [String]
         public var allowedHeaders: [String]
@@ -103,7 +109,7 @@ extension AWS.Bucket {
         public var maxAgeSeconds: Int?
         
         public init(
-            allowedMethods: [HTTPMethod] = [.GET, .HEAD],
+            allowedMethods: [HTTPMethod] = [.get, .head],
             allowedOrigins: [String] = ["*"],
             allowedHeaders: [String] = [],
             exposeHeaders: [String] = [],
@@ -126,10 +132,10 @@ extension AWS.Bucket {
                 )
             }
         }
-
+        
         internal static func isValidOrigin(_ origin: String) -> Bool {
             guard origin != "*" else { return true }
-
+            
             guard let url = URL(string: origin),
                   let scheme = url.scheme,
                   (scheme == "http" || scheme == "https"),
@@ -140,7 +146,7 @@ extension AWS.Bucket {
                   url.fragment == nil else {
                 return false
             }
-
+            
             return true
         }
     }

--- a/Sources/CloudAWS/Components/Bucket.swift
+++ b/Sources/CloudAWS/Components/Bucket.swift
@@ -3,6 +3,7 @@ extension AWS {
         internal let bucket: Resource
         internal let ownershipControls: Resource
         internal let publicAccessBlock: Resource
+        internal let corsConfiguration: Resource?
 
         public var name: Output<String> {
             bucket.id
@@ -18,6 +19,7 @@ extension AWS {
 
         public init(
             _ name: String,
+            cors: [CORSRule]? = nil,
             forceDestroy: Bool = true,
             options: Resource.Options? = nil,
             context: Context = .current
@@ -55,6 +57,95 @@ extension AWS {
                 options: options,
                 context: context
             )
+
+            if let cors {
+                corsConfiguration = Resource(
+                    name: "\(name)-cors",
+                    type: "aws:s3:BucketCorsConfigurationV2",
+                    properties: [
+                        "bucket": bucket.output,
+                        "corsRules": cors.map { rule in
+                            var ruleDict: [String: AnyEncodable] = [
+                                "allowedMethods": AnyEncodable(rule.allowedMethods.map { $0.rawValue }),
+                                "allowedOrigins": AnyEncodable(rule.allowedOrigins),
+                            ]
+                            if !rule.allowedHeaders.isEmpty {
+                                ruleDict["allowedHeaders"] = AnyEncodable(rule.allowedHeaders)
+                            }
+                            if !rule.exposeHeaders.isEmpty {
+                                ruleDict["exposeHeaders"] = AnyEncodable(rule.exposeHeaders)
+                            }
+                            if let maxAge = rule.maxAgeSeconds {
+                                ruleDict["maxAgeSeconds"] = AnyEncodable(maxAge)
+                            }
+                            return AnyEncodable(ruleDict)
+                        },
+                    ],
+                    options: options,
+                    context: context
+                )
+            } else {
+                corsConfiguration = nil
+            }
+        }
+    }
+}
+
+extension AWS.Bucket {
+    public struct CORSRule {
+        public enum HTTPMethod: String {
+            case get = "GET"
+            case put = "PUT"
+            case post = "POST"
+            case delete = "DELETE"
+            case head = "HEAD"
+        }
+
+        public var allowedMethods: [HTTPMethod]
+        public var allowedOrigins: [String]
+        public var allowedHeaders: [String]
+        public var exposeHeaders: [String]
+        public var maxAgeSeconds: Int?
+
+        public init(
+            allowedMethods: [HTTPMethod] = [.get, .head],
+            allowedOrigins: [String] = ["*"],
+            allowedHeaders: [String] = [],
+            exposeHeaders: [String] = [],
+            maxAgeSeconds: Int? = nil
+        ) {
+            for origin in allowedOrigins {
+                Self.validateOrigin(origin)
+            }
+            self.allowedMethods = allowedMethods
+            self.allowedOrigins = allowedOrigins
+            self.allowedHeaders = allowedHeaders
+            self.exposeHeaders = exposeHeaders
+            self.maxAgeSeconds = maxAgeSeconds
+        }
+
+        private static func validateOrigin(_ origin: String) {
+            guard origin != "*" else { return }
+            let isHTTP = origin.hasPrefix("http://")
+            let isHTTPS = origin.hasPrefix("https://")
+            guard isHTTP || isHTTPS else {
+                fatalError(
+                    "[CloudAWS] Invalid CORS origin '\(origin)': must be '*' or start with 'http://' or 'https://'."
+                )
+            }
+            let afterScheme = origin.dropFirst(isHTTPS ? 8 : 7)
+            // Split on '/' to isolate host[:port] from any path
+            let parts = afterScheme.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+            guard !parts.isEmpty, !parts[0].isEmpty else {
+                fatalError(
+                    "[CloudAWS] Invalid CORS origin '\(origin)': missing host."
+                )
+            }
+            guard parts.count == 1 || parts[1].isEmpty else {
+                fatalError(
+                    "[CloudAWS] Invalid CORS origin '\(origin)': origins must not include a path. Use 'https://example.com' not 'https://example.com/path'."
+                )
+            }
         }
     }
 }

--- a/Sources/CloudAWS/Components/Bucket.swift
+++ b/Sources/CloudAWS/Components/Bucket.swift
@@ -1,22 +1,25 @@
+import NIOHTTP1
+import Foundation
+
 extension AWS {
     public struct Bucket: AWSComponent {
         internal let bucket: Resource
         internal let ownershipControls: Resource
         internal let publicAccessBlock: Resource
         internal let corsConfiguration: Resource?
-
+        
         public var name: Output<String> {
             bucket.id
         }
-
+        
         public var region: Output<String> {
             getARN(bucket).region
         }
-
+        
         public var hostname: Output<String> {
             bucket.output.keyPath("bucketRegionalDomainName")
         }
-
+        
         public init(
             _ name: String,
             cors: [CORSRule]? = nil,
@@ -33,7 +36,7 @@ extension AWS {
                 options: options,
                 context: context
             )
-
+            
             ownershipControls = Resource(
                 name: "\(name)-oc",
                 type: "aws:s3:BucketOwnershipControls",
@@ -46,7 +49,7 @@ extension AWS {
                 options: options,
                 context: context
             )
-
+            
             publicAccessBlock = Resource(
                 name: "\(name)-pab",
                 type: "aws:s3:BucketPublicAccessBlock",
@@ -57,7 +60,7 @@ extension AWS {
                 options: options,
                 context: context
             )
-
+            
             if let cors {
                 corsConfiguration = Resource(
                     name: "\(name)-cors",
@@ -93,22 +96,14 @@ extension AWS {
 
 extension AWS.Bucket {
     public struct CORSRule {
-        public enum HTTPMethod: String {
-            case get = "GET"
-            case put = "PUT"
-            case post = "POST"
-            case delete = "DELETE"
-            case head = "HEAD"
-        }
-
         public var allowedMethods: [HTTPMethod]
         public var allowedOrigins: [String]
         public var allowedHeaders: [String]
         public var exposeHeaders: [String]
         public var maxAgeSeconds: Int?
-
+        
         public init(
-            allowedMethods: [HTTPMethod] = [.get, .head],
+            allowedMethods: [HTTPMethod] = [.GET, .HEAD],
             allowedOrigins: [String] = ["*"],
             allowedHeaders: [String] = [],
             exposeHeaders: [String] = [],
@@ -123,29 +118,30 @@ extension AWS.Bucket {
             self.exposeHeaders = exposeHeaders
             self.maxAgeSeconds = maxAgeSeconds
         }
-
+        
         private static func validateOrigin(_ origin: String) {
-            guard origin != "*" else { return }
-            let isHTTP = origin.hasPrefix("http://")
-            let isHTTPS = origin.hasPrefix("https://")
-            guard isHTTP || isHTTPS else {
+            guard isValidOrigin(origin) else {
                 fatalError(
-                    "[CloudAWS] Invalid CORS origin '\(origin)': must be '*' or start with 'http://' or 'https://'."
+                    "Invalid CORS origin '\(origin)': must be '*' or a valid origin URL (scheme://host) without path, query, or fragment."
                 )
             }
-            let afterScheme = origin.dropFirst(isHTTPS ? 8 : 7)
-            // Split on '/' to isolate host[:port] from any path
-            let parts = afterScheme.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
-            guard !parts.isEmpty, !parts[0].isEmpty else {
-                fatalError(
-                    "[CloudAWS] Invalid CORS origin '\(origin)': missing host."
-                )
+        }
+
+        internal static func isValidOrigin(_ origin: String) -> Bool {
+            guard origin != "*" else { return true }
+
+            guard let url = URL(string: origin),
+                  let scheme = url.scheme,
+                  (scheme == "http" || scheme == "https"),
+                  let host = url.host,
+                  !host.isEmpty,
+                  url.path == "/" || url.path.isEmpty,
+                  url.query == nil,
+                  url.fragment == nil else {
+                return false
             }
-            guard parts.count == 1 || parts[1].isEmpty else {
-                fatalError(
-                    "[CloudAWS] Invalid CORS origin '\(origin)': origins must not include a path. Use 'https://example.com' not 'https://example.com/path'."
-                )
-            }
+
+            return true
         }
     }
 }
@@ -159,14 +155,14 @@ extension AWS.Bucket: Linkable {
             "s3:ListBucket",
         ]
     }
-
+    
     public var resources: [Output<String>] {
         [
             "\(bucket.arn)",
             "\(bucket.arn)/*",
         ]
     }
-
+    
     public var properties: LinkProperties? {
         return .init(
             type: "bucket",

--- a/Tests/CloudAWSTests/BucketCORSRuleTests.swift
+++ b/Tests/CloudAWSTests/BucketCORSRuleTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+@testable import CloudAWS
+
+@Suite("AWS Bucket CORS Rule Tests")
+struct BucketCORSRuleTests {
+    @Test("Accepts wildcard and origin URLs without path query or fragment")
+    func acceptsValidOrigins() {
+        #expect(AWS.Bucket.CORSRule.isValidOrigin("*"))
+        #expect(AWS.Bucket.CORSRule.isValidOrigin("https://example.com"))
+        #expect(AWS.Bucket.CORSRule.isValidOrigin("http://localhost"))
+        #expect(AWS.Bucket.CORSRule.isValidOrigin("https://example.com:8443"))
+    }
+
+    @Test("Rejects invalid CORS origins")
+    func rejectsInvalidOrigins() {
+        #expect(!AWS.Bucket.CORSRule.isValidOrigin("example.com"))
+        #expect(!AWS.Bucket.CORSRule.isValidOrigin("ftp://example.com"))
+        #expect(!AWS.Bucket.CORSRule.isValidOrigin("https://example.com/path"))
+        #expect(!AWS.Bucket.CORSRule.isValidOrigin("https://example.com?foo=bar"))
+        #expect(!AWS.Bucket.CORSRule.isValidOrigin("https://example.com#fragment"))
+    }
+}


### PR DESCRIPTION
This PR adds CORS configuration support to `AWS.Bucket` and includes validation for allowed origin values. Also adds AWS test coverage for valid and invalid CORS origin formats.