### PR TITLE
Bump CI and builder support to Swift 6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        swift: ["6.3"]
+        swift: ["6.2", "6.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        swift: ["6.2"]
+        swift: ["6.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Sources/CloudCore/Builder.swift
+++ b/Sources/CloudCore/Builder.swift
@@ -50,6 +50,8 @@ extension Builder {
                 imageName = "swift:6.1-amazonlinux2"
             case "6.2":
                 imageName = "swift:6.2-amazonlinux2"
+            case "6.3":
+                imageName = "swift:6.3-amazonlinux2"
             default:
                 fatalError("Unsupported Swift version: \(swiftVersion)")
             }
@@ -93,6 +95,8 @@ extension Builder {
             imageName = "swift:6.1-noble"
         case "6.2":
             imageName = "swift:6.2-noble"
+        case "6.3":
+            imageName = "swift:6.3-noble"
         default:
             fatalError("Unsupported Swift version: \(swiftVersion)")
         }


### PR DESCRIPTION
This pull request adds support for Swift 6.3

Changes include:
- Added `swift:6.3-amazonlinux2` and `swift:6.3-noble` for respective platforms.
- Updated the GitHub Actions test matrix from Swift 6.2 to Swift 6.3.

> No breaking changes; ensures compatibility with Swift 6.3.